### PR TITLE
UTF-8 / non-ASCII character support for filenames

### DIFF
--- a/gramgrab.py
+++ b/gramgrab.py
@@ -1,6 +1,7 @@
 import os
 import argparse
 import asyncio
+import ast
 from telethon import TelegramClient
 from telethon.tl.functions.channels import GetFullChannelRequest
 from telethon.tl.types import MessageMediaDocument
@@ -29,11 +30,12 @@ concurrent_downloads = args.concurrent_downloads
 
 async def download_zip_file(client, message):
     file_name = message.media.document.attributes[0].file_name
-    file_name_utf8 = file_name.encode('utf-8').decode('unicode_escape')
+    file_name_utf8 = ast.literal_eval(f'"{file_name}"')
     file_path = os.path.join(os.getcwd(), file_name_utf8)
-    print(f'Downloading {repr(file_name_utf8)}...')
+    print(f'Downloading {file_name_utf8}...')
     await client.download_media(message, file_path)
-    print(f'{repr(file_name_utf8)} downloaded.')
+    print(f'{file_name_utf8} downloaded.')
+
 
 async def download_zip_files(client, channel_url):
     channel = await client.get_entity(channel_url)

--- a/gramgrab.py
+++ b/gramgrab.py
@@ -29,10 +29,11 @@ concurrent_downloads = args.concurrent_downloads
 
 async def download_zip_file(client, message):
     file_name = message.media.document.attributes[0].file_name
-    file_path = os.path.join(os.getcwd(), file_name)
-    print(f'Downloading {file_name}...')
+    file_name_utf8 = file_name.encode('utf-8').decode('unicode_escape')
+    file_path = os.path.join(os.getcwd(), file_name_utf8)
+    print(f'Downloading {repr(file_name_utf8)}...')
     await client.download_media(message, file_path)
-    print(f'{file_name} downloaded.')
+    print(f'{repr(file_name_utf8)} downloaded.')
 
 async def download_zip_files(client, channel_url):
     channel = await client.get_entity(channel_url)


### PR DESCRIPTION
In this updated function, the file name is explicitly decoded as UTF-8 using encode('utf-8').decode('unicode_escape'). This should properly handle non-ASCII characters in the file name when printing and saving the file. Using repr() to print the file name will display the escaped version of the file name, making it easier to see the actual characters.